### PR TITLE
Hf ga4 custom dimensions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import './App.scss'
 import ReactGA from "react-ga4"
-
 // React Imports
 import { useEffect, useMemo, useRef, useState } from 'react'
 
@@ -221,11 +220,16 @@ function App() {
         if (response.length > 0) {
           const location = response.pop();
 
+          ReactGA.set({
+            link_text: `${location!.title.rendered}`, 
+            link_url: `${location!.link}`
+          })
           ReactGA.event({
             category: "link",
             action: "click_internal_link",
             label: `${location!.title.rendered}`,
-          });          
+          })      
+
           html = `<a class="location-link" href="${location!.link}" onClick="{() => trackLinkClick(${location!.title.rendered}) }" target="_blank">${feature?.properties?.Name}</a>`;
         } else {
           html = `<span class="location-link">${feature?.properties?.Name}</span>`
@@ -278,6 +282,10 @@ function App() {
   };
 
   const campusHandler = (campus: Campus) => {
+    ReactGA.set({
+      link_text: `${campus.name}`, 
+      link_url: ''
+    })
     ReactGA.event({
       category: "campus_menu",
       action: "click_campus_menu",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,11 +219,6 @@ function App() {
 
         if (response.length > 0) {
           const location = response.pop();
-
-          ReactGA.set({
-            link_text: `${location!.title.rendered}`, 
-            link_url: `${location!.link}`
-          })
           ReactGA.event({
             category: "link",
             action: "click_internal_link",
@@ -282,10 +277,6 @@ function App() {
   };
 
   const campusHandler = (campus: Campus) => {
-    ReactGA.set({
-      link_text: `${campus.name}`, 
-      link_url: ''
-    })
     ReactGA.event({
       category: "campus_menu",
       action: "click_campus_menu",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,6 +223,9 @@ function App() {
             category: "link",
             action: "click_internal_link",
             label: `${location!.title.rendered}`,
+          },{
+            link_url: `${location!.link}`,
+            link_text: `${location!.title.rendered}`
           })      
 
           html = `<a class="location-link" href="${location!.link}" onClick="{() => trackLinkClick(${location!.title.rendered}) }" target="_blank">${feature?.properties?.Name}</a>`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,22 +205,14 @@ function App() {
 
         if (response.length > 0) {
           const location = response.pop();
-          
-          ReactGA.gtag("set", "user_properties", {
-            link_url: `${location!.link}`
-          });
 
-         ReactGA.gtag("set", "user_properties", {
-          link_text: `${location!.title.rendered}`
-          });
-
-          ReactGA.event({
-            category: "link",
-            action: "click_internal_link",
-            label: `${location!.title.rendered}`
-            }
-          )      
-
+          ReactGA.gtag('event', 'click_internal_link', {
+            'event_category': 'link',
+            'event_label': `${location!.title.rendered}`,
+            'link_text': `${location!.title.rendered}`,
+            'link_url': `${location!.link}`
+        });
+        
           html = `<a class="location-link" href="${location!.link}" onClick="{() => trackLinkClick(${location!.title.rendered}) }" target="_blank">${feature?.properties?.Name}</a>`;
         } else {
           html = `<span class="location-link">${feature?.properties?.Name}</span>`
@@ -273,16 +265,12 @@ function App() {
   };
 
   const campusHandler = (campus: Campus) => {
-  
-   ReactGA.gtag("set", "user_properties", {
-    link_text: `${campus.name}`
-    });
-    
-    ReactGA.event({
-      category: "campus_menu",
-      action: "click_campus_menu",
-      label: `${campus.name}`,
-    });
+
+    ReactGA.gtag('event', 'click_campus_menu', {
+      'event_category': 'campus_menu',
+      'event_label': `${campus.name}`,
+      'link_text': `${campus.name}`
+  });
 
     mapRef.current!.flyTo({
       center: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,20 +74,6 @@ const FOOTER_SOCIAL_ID = import.meta.env.VITE_REMOTE_SOCIAL_LINKS_ID;
 const REACT_MEASUREMENT_ID = import.meta.env.VITE_REACTGA_MEASUREMENT_ID || '';
 
 function App() {
-  if(REACT_MEASUREMENT_ID) {
-  ReactGA.initialize(REACT_MEASUREMENT_ID, {
-    gaOptions: {
-      debug_mode: true,
-    },
-    gtagOptions: {
-      debug_mode: true,
-    },
-  });
-
-  // Send pageview with a custom path
-  ReactGA.send({ hitType: "pageview", page: "/map/", title: "UCF Campus Map" });
-}
-
   const initialLng = -81.200142;
   const intitalLat = 28.602368;
   const initialZoom = 15;
@@ -219,14 +205,21 @@ function App() {
 
         if (response.length > 0) {
           const location = response.pop();
+          
+          ReactGA.gtag("set", "user_properties", {
+            link_url: `${location!.link}`
+          });
+
+         ReactGA.gtag("set", "user_properties", {
+          link_text: `${location!.title.rendered}`
+          });
+
           ReactGA.event({
             category: "link",
             action: "click_internal_link",
-            label: `${location!.title.rendered}`,
-          },{
-            link_url: `${location!.link}`,
-            link_text: `${location!.title.rendered}`
-          })      
+            label: `${location!.title.rendered}`
+            }
+          )      
 
           html = `<a class="location-link" href="${location!.link}" onClick="{() => trackLinkClick(${location!.title.rendered}) }" target="_blank">${feature?.properties?.Name}</a>`;
         } else {
@@ -280,6 +273,11 @@ function App() {
   };
 
   const campusHandler = (campus: Campus) => {
+  
+   ReactGA.gtag("set", "user_properties", {
+    link_text: `${campus.name}`
+    });
+    
     ReactGA.event({
       category: "campus_menu",
       action: "click_campus_menu",
@@ -304,6 +302,15 @@ function App() {
   const onMouseLeaveInteractive = (_: MapLayerMouseEvent) => {
     mapRef.current!.getCanvas().style.cursor = '';
   }
+
+  useMemo(() => {
+    if ( REACT_MEASUREMENT_ID ) {
+      ReactGA.initialize(REACT_MEASUREMENT_ID);
+  
+      // Send pageview with a custom path
+      ReactGA.send({ hitType: "pageview", page: "/map/", title: "UCF Campus Map" });
+    }
+  }, []);
 
   useMemo(() => {
     // Location data

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,12 @@ const FOOTER_SOCIAL_ID = import.meta.env.VITE_REMOTE_SOCIAL_LINKS_ID;
 const REACT_MEASUREMENT_ID = import.meta.env.VITE_REACTGA_MEASUREMENT_ID || '';
 
 function App() {
+
+  if(REACT_MEASUREMENT_ID) {
+    ReactGA.initialize(REACT_MEASUREMENT_ID)
+    // Send pageview with a custom path
+    ReactGA.send({ hitType: "pageview", page: "/map/", title: "UCF Campus Map" });
+  }
   const initialLng = -81.200142;
   const intitalLat = 28.602368;
   const initialZoom = 15;

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -26,6 +26,7 @@ export default function SearchResults(props: SearchResultsProps) {
   }, [searchQuery, 500])
 
   useEffect(() => {
+    ReactGA.set({});
     ReactGA.event({
       category: "map_search",
       action: "search",

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -33,7 +33,6 @@ export default function SearchResults(props: SearchResultsProps) {
     });
   },[debouncedSearchQuery])
 
-
   return (
     <div className='search-control-wrapper rounded'>
       <div className='input-group'>

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -26,7 +26,6 @@ export default function SearchResults(props: SearchResultsProps) {
   }, [searchQuery, 500])
 
   useEffect(() => {
-    ReactGA.set({});
     ReactGA.event({
       category: "map_search",
       action: "search",

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -26,6 +26,11 @@ export default function SearchResults(props: SearchResultsProps) {
   }, [searchQuery, 500])
 
   useEffect(() => {
+    
+    ReactGA.gtag("set", "user_properties", {
+      link_text: `${debouncedSearchQuery}`
+    });
+
     ReactGA.event({
       category: "map_search",
       action: "search",

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -27,15 +27,12 @@ export default function SearchResults(props: SearchResultsProps) {
 
   useEffect(() => {
     
-    ReactGA.gtag("set", "user_properties", {
-      link_text: `${debouncedSearchQuery}`
-    });
+    ReactGA.gtag('event', 'search', {
+      'event_category': 'map_search',
+      'event_label': `${debouncedSearchQuery}`,
+      'link_text': `${debouncedSearchQuery}`,
+  });
 
-    ReactGA.event({
-      category: "map_search",
-      action: "search",
-      label: `${debouncedSearchQuery}`,
-    });
   },[debouncedSearchQuery])
 
   return (


### PR DESCRIPTION
**Description**
In order to add the custom dimensions, we are unable to use `react.event()` instead we need to use gtag then we are able to add as many as possible custom dimensions.

**Motivation and Context**
We want to track our custom dimensions such as link_url and link_text.

**How Has This Been Tested?**
Tested Dev and we are able to track those custom dimensions.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
