### PR TITLE
searchresult box will be hide after user clicks on result.

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -17,6 +17,7 @@ interface SearchResultsProps {
 export default function SearchResults(props: SearchResultsProps) {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string>('');
+  const [searchBoxVisibility,setSearchBoxVisibility] = useState<boolean>(false);
 
   useEffect(() => {
     const delaySearchQueryTimeOutId = setTimeout(() => {
@@ -44,8 +45,9 @@ export default function SearchResults(props: SearchResultsProps) {
         aria-label='Search for locations,services, parking, and more'
         value={searchQuery}
         onChange={(e) => {
+          !searchBoxVisibility && e.target.value ?  setSearchBoxVisibility(true) : ''
           setSearchQuery(e.target.value);
-          props.searchData(e.target.value)
+          props.searchData(e.target.value);
         }}
         tabIndex={0}
         role='searchbox'
@@ -54,11 +56,13 @@ export default function SearchResults(props: SearchResultsProps) {
           {
           searchQuery !== '' ? (
             <img width={20} src={closeIcon} onClick={() => {
+              searchBoxVisibility ? setSearchBoxVisibility (false) : ''
               props.searchData(null)
               setSearchQuery('');
             }}
             onKeyDown={(e)=>{
               if(e.key === 'Enter'){
+                searchBoxVisibility ? setSearchBoxVisibility (false) : ''
                 props.searchData(null)
                 setSearchQuery('');
               }
@@ -72,7 +76,7 @@ export default function SearchResults(props: SearchResultsProps) {
           ) }
         </div>
       </div>  
-      {props.searchResults && props.searchResults.length > 0 && (
+      {props.searchResults && props.searchResults.length > 0 && searchBoxVisibility && (
         <div className='search-results-container'>
           <h2 className='sr-only'>Search Results</h2>
           <ul role="listbox" tabIndex={-1} id='search-results' className='search-results'>
@@ -81,9 +85,14 @@ export default function SearchResults(props: SearchResultsProps) {
                 <li key={result!.properties!.Name} className='list-item search-result'>
                   <a
                     className='search-result-link'
-                    onClick={() => props.onSearchResultClick(result)}
+                    onClick={() => {
+                      setSearchBoxVisibility(false);
+                      props.onSearchResultClick(result);
+                      }
+                    }
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
+                        setSearchBoxVisibility(false);
                         props.onSearchResultClick(result);
                       }
                     }}


### PR DESCRIPTION
**Description**
Added the logic to hide the search result box when the user clicks on a link.

**Motivation and Context**
There was an issue on mobile devices, when a user search something, a list of menu was displayed over the map so a user couldn't escape from that unless remove the result.

**How Has This Been Tested?**
Tested on Dev Environment.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
